### PR TITLE
Add support to a ready to use PSR6 cache instance

### DIFF
--- a/src/Base/BaseAPI.php
+++ b/src/Base/BaseAPI.php
@@ -385,6 +385,9 @@ abstract class BaseAPI
 	{
 		try
 		{
+			if (is_object($cacheProviderClass) && $cacheProviderClass instanceof CacheItemPoolInterface) {
+				return $cacheProviderClass;
+			}
 			//  Creates reflection of specified cache provider (can be user-made)
 			$cacheProvider = new \ReflectionClass($cacheProviderClass);
 			//  Checks if this cache provider implements required interface


### PR DESCRIPTION
Hello, 

When passing an already instanciated cache implementing a PSR6 cache, your library tries to `_initializeCacheProvider` which is trying to instanciate the `$cacheProviderClass`.

In my case, i'm nice, I'm giving the library a Symfony cache object which implements the PSR6  `CacheItemPoolInterface`
With this patch, it's just using the cache service as is since it's all ready ;)